### PR TITLE
Ŝanĝis la ligilon en event_map_url de Google Maps al OpenStreetMap

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -35,7 +35,7 @@ module EventsHelper
   end
 
   def event_map_url(event)
-    "https://www.google.com/maps/search/?api=1&query=#{event.full_address}"
+    "https://www.openstreetmap.org/search?query=#{event.full_address}"
   end
 
   def days_to_event(event)


### PR DESCRIPTION
La ĉefpaĝo kaj la eventpaĝoj uzas OpenStreetMap kaj ne plu Google Maps. Estas nun logike, ke la ligilo ĉe la eventpaĝoj ankaŭ iru al OpenStreetMap anstataŭ al Google Maps.